### PR TITLE
Avoid deprecated `std::iterator` in `neighbors.h`

### DIFF
--- a/_project/neighbors.h
+++ b/_project/neighbors.h
@@ -64,13 +64,14 @@ public:
         return seed_(i + 1) - seed_(i);
     }
 
-    class iterator : public std::iterator<
-            std::input_iterator_tag,
-            std::tuple<int, int>,    // value_type
-            std::tuple<int, int>,    // difference_type
-            std::tuple<int, int> *,  // pointer
-            std::tuple<int, int>> {  // reference
+    class iterator {
     public:
+        using iterator_category = std::input_iterator_tag;
+        using value_type = std::tuple<int, int>;
+        using difference_type = std::tuple<int, int>;
+        using pointer = std::tuple<int, int> *;
+        using reference = std::tuple<int, int>;
+
         explicit iterator(const Eigen::ArrayXi &seed, const Eigen::ArrayXi &neighbors, int i, int n)
                 : seed_{seed}, neighbors_{neighbors}, i_{i}, n_{n} {}
 


### PR DESCRIPTION
Deprecated `std::iterator` since C++17 is substituted.
Reference: https://www.fluentcpp.com/2018/05/08/std-iterator-deprecated/